### PR TITLE
Update CircleCI version marker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 commands:
   build:


### PR DESCRIPTION
Couldn't get CircleCI to build and fix the error until the changes were already on the `main` branch.
