### PR TITLE
First unit test

### DIFF
--- a/OP2BitmapConverter.vcxproj
+++ b/OP2BitmapConverter.vcxproj
@@ -157,6 +157,9 @@
       <Project>{980d53d9-f9e2-4682-9307-1303c9e42313}</Project>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="src\ConsoleArguments.h" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/src/ConsoleArguments.h
+++ b/src/ConsoleArguments.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <string>
+#include <stdexcept>
+
+struct ConsoleArguments
+{
+	std::string sourcePath;
+	std::string destinationPath;
+};
+
+inline ConsoleArguments ParseConsoleArguments(int argc, char** argv)
+{
+	if (argc > 3)
+	{
+		throw std::runtime_error("Too many command line arguments provided.");
+	}
+	if (argc < 3)
+	{
+		throw std::runtime_error("Too few command line arguments provided.");
+	}
+
+	return ConsoleArguments{ argv[1], argv[2] };
+}

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -1,19 +1,12 @@
+#include "ConsoleArguments.h"
 #include "OP2Utility.h"
 #include <iostream>
-#include <string>
 #include <stdexcept>
 
 using namespace OP2Utility;
 
 static const std::string version = "0.0.1";
 
-struct ConsoleArguments
-{
-	std::string sourcePath;
-	std::string destinationPath;
-};
-
-ConsoleArguments ParseConsoleArguments(int argc, char** argv);
 void OutputHelp();
 
 int main(int argc, char** argv)
@@ -32,19 +25,7 @@ int main(int argc, char** argv)
 	return 0;
 }
 
-ConsoleArguments ParseConsoleArguments(int argc, char** argv)
-{
-	if (argc > 3)
-	{
-		throw std::runtime_error("Too many command line arguments provided.");
-	}
-	if (argc < 3)
-	{
-		throw std::runtime_error("Too few command line arguments provided.");
-	}
 
-	return ConsoleArguments{ argv[1], argv[2] };
-}
 
 void OutputHelp()
 {

--- a/test/ConsoleArguments.test.cpp
+++ b/test/ConsoleArguments.test.cpp
@@ -1,0 +1,25 @@
+#include "../src/ConsoleArguments.h"
+#include <gtest/gtest.h>
+#include <string>
+#include <stdexcept>
+#include <array>
+
+char* SampleApplicationPath("C:/SampleFolder/SampleApplication.exe");
+
+TEST(ConsoleArguments, ArgumentCount)
+{
+	{ // Proper argument count
+		std::array<char*, 3> consoleInput{ SampleApplicationPath, "First Argument", "Second Argument"};
+		auto arguments = ParseConsoleArguments(consoleInput.size(), consoleInput.data());
+		EXPECT_EQ(consoleInput[1], arguments.sourcePath);
+		EXPECT_EQ(consoleInput[2], arguments.destinationPath);
+	}
+	{ // Too few arguments
+		std::array<char*, 2> consoleInput{ SampleApplicationPath, "First Argument" };
+		EXPECT_THROW(ParseConsoleArguments(consoleInput.size(), consoleInput.data()), std::runtime_error);
+	}
+	{ // Too many arguments
+		std::array<char*, 4> consoleInput{ SampleApplicationPath, "First Argument", "Second Argument", "Third Argument" };
+		EXPECT_THROW(ParseConsoleArguments(consoleInput.size(), consoleInput.data()), std::runtime_error);
+	}
+}

--- a/test/OP2BitmapConverterTest.vcxproj
+++ b/test/OP2BitmapConverterTest.vcxproj
@@ -49,6 +49,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="ConsoleArguments.test.cpp" />
     <ClCompile Include="test.cpp" />
   </ItemGroup>
   <ItemDefinitionGroup />

--- a/test/OP2BitmapConverterTest.vcxproj
+++ b/test/OP2BitmapConverterTest.vcxproj
@@ -50,7 +50,6 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ConsoleArguments.test.cpp" />
-    <ClCompile Include="test.cpp" />
   </ItemGroup>
   <ItemDefinitionGroup />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,3 +1,0 @@
-#include <gtest/gtest.h>
-
-


### PR DESCRIPTION
Long term looks like we need to split OP2BitmapConverter into 2 projects to facilitate a static library project for unit testing and another project to form the executable...

Wish there was a simpler way to do this.