### PR TITLE
Allow reading tilesets from volumes using the ResourceManager

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -14,7 +14,10 @@ int main(int argc, char** argv)
 	try {
 		auto consoleArguments = ParseConsoleArguments(argc, argv);
 
-		Tileset::ReadTileset(Stream::FileReader(consoleArguments.sourcePath)).WriteIndexed(consoleArguments.destinationPath);
+		ResourceManager resourceManager(XFile::GetDirectory(consoleArguments.sourcePath));
+
+		auto stream = resourceManager.GetResourceStream(XFile::GetFilename(consoleArguments.sourcePath));
+		Tileset::ReadTileset(*stream).WriteIndexed(consoleArguments.destinationPath);
 	}
 	catch (std::exception& e) {
 		std::cout << "An error was encountered. " << e.what() << std::endl << std::endl;


### PR DESCRIPTION
Manual testing produces a bug:

An error was encountered. Seek backward by offset of 4 is beyond the bounds of the stream slice. Source stream: art.vol

This is caused by the command PeekIsCustomTileset when it reaches the subroutine reader.SeekBackward.

```C++
bool PeekIsCustomTileset(Stream::BidirectionalReader& reader)
{
	Tag tag;
	reader.Read(tag);
	reader.SeekBackward(sizeof(tag));

	return tag == TagFileSignature;
}
```

I suspect there is an underlying bug in how the stream position is being tracked in a Stream::Slice, but I haven't investigated further yet...